### PR TITLE
Split functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ hash.at("foo", "bar", "baz")
 # => :value
 ```
 
-You can also *namespace* the keys with dots `.` or colons `:` if they are all Strings or Symbols, respectively.
+You can also *namespace* the keys with dots `.` or colons `:` using the `at_path` method if they are all Strings or Symbols, respectively.
 
 ```ruby
 Hash.include(Fat)
@@ -72,7 +72,7 @@ hash = {
   }
 }
 
-hash.at("foo.bar.baz")
+hash.at_path("foo.bar.baz")
 # => :value
 
 hash = {
@@ -83,7 +83,7 @@ hash = {
   }
 }
 
-hash.at("foo:bar:baz")
+hash.at_path("foo:bar:baz")
 # => :value
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ hash.at("foo", "bar", "baz")
 # => :value
 ```
 
-You can also *namespace* the keys with dots `.` or colons `:` using the `at_path` method if they are all Strings or Symbols, respectively.
+You can also *namespace* the keys with dots `.` or colons `:` using the `at_string_path` and `at_symbol_path` method if they are all Strings or Symbols, respectively.
 
 ```ruby
 Hash.include(Fat)
@@ -72,7 +72,7 @@ hash = {
   }
 }
 
-hash.at_path("foo.bar.baz")
+hash.at_string_path("foo.bar.baz")
 # => :value
 
 hash = {
@@ -83,7 +83,7 @@ hash = {
   }
 }
 
-hash.at_path("foo:bar:baz")
+hash.at_symbol_path("foo:bar:baz")
 # => :value
 ```
 

--- a/lib/fat.rb
+++ b/lib/fat.rb
@@ -1,9 +1,12 @@
 module Fat
   FatError = Class.new(StandardError)
 
-  def self.at(hash, *args)
-    fields = parse_args(*args)
+  def self.at_path(hash, path)
+    fields = parse_path(path)
+    self.at(hash, *fields)
+  end
 
+  def self.at(hash, *fields)
     fields[0..-1].each_with_index do |field, index|
       hash = hash[field]
       if index != fields.length - 1 && !hash.kind_of?(Hash)
@@ -14,22 +17,19 @@ module Fat
     hash
   end
 
-  def self.parse_args(*args)
-    return args if args.length > 1
-
-    fields = args.first.split(".")
+  def self.parse_path(path)
+    fields = path.split(".")
 
     if fields.length == 1
-      fields = args.first.split(":")
-
-      if fields.length == 1
-        raise FatError, "Single argument expected to be a namespace with dots (.) or colons (:)"
-      else
-        fields.map(&:to_sym)
-      end
+      fields = path.split(":")
+      fields.map(&:to_sym)
     else
       fields
     end
+  end
+
+  def at_path(*args)
+    Fat.at_path(self, *args)
   end
 
   def at(*args)

--- a/lib/fat.rb
+++ b/lib/fat.rb
@@ -1,8 +1,13 @@
 module Fat
   FatError = Class.new(StandardError)
 
-  def self.at_path(hash, path)
-    fields = parse_path(path)
+  def self.at_string_path(hash, path)
+    fields = path.split('.')
+    self.at(hash, *fields)
+  end
+
+  def self.at_symbol_path(hash, path)
+    fields = path.split(':').map(&:to_sym)
     self.at(hash, *fields)
   end
 
@@ -17,23 +22,15 @@ module Fat
     hash
   end
 
-  def self.parse_path(path)
-    fields = path.split(".")
-
-    if fields.length == 1
-      fields = path.split(":")
-      fields.map(&:to_sym)
-    else
-      fields
-    end
+  def at_string_path(path)
+    Fat.at_string_path(self, path)
   end
 
-  def at_path(*args)
-    Fat.at_path(self, *args)
+  def at_symbol_path(path)
+    Fat.at_symbol_path(self, path)
   end
 
   def at(*args)
     Fat.at(self, *args)
   end
 end
-

--- a/test/fat_test.rb
+++ b/test/fat_test.rb
@@ -32,9 +32,9 @@ scope do
   end
 
   test "namespaced strings" do |hash|
-    assert_equal :found, Fat.at_path(hash, "foo.bar.baz")
+    assert_equal :found, Fat.at_string_path(hash, "foo.bar.baz")
 
-    exception = assert_raise(Fat::FatError) { Fat.at_path(hash, "foo.not.baz") }
+    exception = assert_raise(Fat::FatError) { Fat.at_string_path(hash, "foo.not.baz") }
     assert_equal "No hash found at foo.not", exception.message
   end
 end
@@ -51,9 +51,9 @@ scope do
   end
 
   test "namespaced symbols" do |hash|
-    assert_equal :found, Fat.at_path(hash, "foo:bar:baz")
+    assert_equal :found, Fat.at_symbol_path(hash, "foo:bar:baz")
 
-    exception = assert_raise(Fat::FatError) { Fat.at_path(hash, "foo:not:baz") }
+    exception = assert_raise(Fat::FatError) { Fat.at_symbol_path(hash, "foo:not:baz") }
     assert_equal "No hash found at foo.not", exception.message
   end
 end
@@ -77,7 +77,7 @@ scope do
 
   test "honor Fat interface" do |hash|
     assert_equal :found, hash.at("foo", "bar", "baz")
-    assert_equal :found, hash.at_path("foo.bar.baz")
+    assert_equal :found, hash.at_string_path("foo.bar.baz")
   end
 end
 

--- a/test/fat_test.rb
+++ b/test/fat_test.rb
@@ -21,13 +21,6 @@ scope do
 end
 
 scope do
-  test "single argument must be a namespace" do
-    exception = assert_raise(Fat::FatError) { Fat.at({"foo" => "bar"}, "foo") }
-    assert_equal "Single argument expected to be a namespace with dots (.) or colons (:)", exception.message
-  end
-end
-
-scope do
   setup do
     {
       "foo" => {
@@ -39,9 +32,9 @@ scope do
   end
 
   test "namespaced strings" do |hash|
-    assert_equal :found, Fat.at(hash, "foo.bar.baz")
+    assert_equal :found, Fat.at_path(hash, "foo.bar.baz")
 
-    exception = assert_raise(Fat::FatError) { Fat.at(hash, "foo.not.baz") }
+    exception = assert_raise(Fat::FatError) { Fat.at_path(hash, "foo.not.baz") }
     assert_equal "No hash found at foo.not", exception.message
   end
 end
@@ -58,9 +51,9 @@ scope do
   end
 
   test "namespaced symbols" do |hash|
-    assert_equal :found, Fat.at(hash, "foo:bar:baz")
+    assert_equal :found, Fat.at_path(hash, "foo:bar:baz")
 
-    exception = assert_raise(Fat::FatError) { Fat.at(hash, "foo:not:baz") }
+    exception = assert_raise(Fat::FatError) { Fat.at_path(hash, "foo:not:baz") }
     assert_equal "No hash found at foo.not", exception.message
   end
 end
@@ -84,7 +77,7 @@ scope do
 
   test "honor Fat interface" do |hash|
     assert_equal :found, hash.at("foo", "bar", "baz")
-    assert_equal :found, hash.at("foo.bar.baz")
+    assert_equal :found, hash.at_path("foo.bar.baz")
   end
 end
 

--- a/test/fat_test.rb
+++ b/test/fat_test.rb
@@ -92,3 +92,8 @@ scope do
   end
 end
 
+scope do
+  test 'one element string path' do
+    assert_equal 'foo', Fat.at_string_path({ 'a' => 'foo'}, 'a')
+  end
+end


### PR DESCRIPTION
Hey tonchis :smile: 

We talked about this sometime via XMPP or IRC. I think it makes sense to split the functionality of Fat into multiple methods. So this is the solution I came up with, and as you can see it removes almost all conditionals :wink: So this is my proposal:
- `at` takes the keys as arguments, like this: `Fat.at(data, 'a', 'b', 'c')`. It can be a mixture of Strings and Symbols.
- `at_string_path` takes a path separated by dots. It will search for keys that are Strings. So `Fat.at_string_path(data, 'a.b.c')` will look for String keys.
- `at_symbol_path` takes a path separated by colons. It will search for keys that are Symbols. So `Fat.at_symbol_path(data, 'a:b:c')` will look for Symbol keys.

What do you think? This is definitely a breaking change and probably means bumping to 2.0 if merged :wink: But I think it reduces the complexity of the implementation and allows the usecase of '1 element pathes' like `Fat.at_string_path({ 'a' => 'foo'}, 'a')`.
